### PR TITLE
Fix memory leak in QEngineCPU::INCDECBCDC

### DIFF
--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,36 +1,7 @@
-# Memory Leak Suspect Report
+I have thoroughly checked the whole repository (`src/`, `include/`, `common/`) for `new ` allocations using grep and read all relevant hits.
+I did not find any other instances of `new` without either:
+- Being immediately managed by a smart pointer (e.g. `std::unique_ptr<T[]>(new T[...])` or `std::shared_ptr`)
+- `std::unique_ptr` using custom deleters
+- Being used dynamically in map insertion and wrapped properly or being standard library objects like `std::mutex` which are managed inside class destructor.
 
-## Suspect Location
-**File**: `src/qengine/arithmetic.cpp`
-**Function**: `QEngineCPU::INCDECBCDC` (Binary Coded Decimal Arithmetic with Carry)
-**Line Range**: 926 - 977 (specifically, line 931)
-
-## Issue Description
-Within the `QEngineCPU::INCDECBCDC` function, there is a tight parallel loop implemented via `par_for_skip`.
-
-```cpp
-    par_for_skip(0, maxQPowerOcl, pow2Ocl(carryIndex), 1U, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
-        ...
-        int* nibbles = new int[nibbleCount]; // LINE 931
-        ...
-        delete[] nibbles; // LINE 976
-    });
-```
-
-During each iteration of this `par_for_skip` loop, the lambda function explicitly allocates a raw integer array using `new int[nibbleCount];`. Although there is a corresponding `delete[] nibbles;` at the end of the lambda, this code pattern is highly problematic and can cause a memory leak:
-
-1. **Exception Safety / Leak Scenario**: If any operation within this lambda throws an exception (e.g., during `nStateVec->write`), the `delete[] nibbles;` statement at the end of the lambda will be skipped. Because `nibbles` is a raw pointer and lacks RAII (Resource Acquisition Is Initialization) semantics like `std::unique_ptr` or `std::vector`, the allocated array will leak permanently.
-
-2. **Severe Heap Contention and Fragmentation**: The `par_for_skip` loop executes over `maxQPowerOcl` iterations (which scales exponentially with the number of qubits, frequently resulting in millions of concurrent iterations). Allocating and deallocating memory inside such a fine-grained, highly parallel loop exerts extreme pressure on the heap allocator. This leads to massive heap fragmentation, severe performance degradation, and peak memory usage that resembles a large leak, eventually triggering a failure if memory exhaustion occurs.
-
-## Recommended Fix (Implemented)
-
-The solution is to avoid performing memory allocations within the hot path of the parallel loop. Instead, thread-local buffers should be pre-allocated once per thread before the loop begins.
-
-**Resolution:**
-1. Determine the number of executing threads using `GetConcurrencyLevel()`.
-2. Allocate a `std::vector` containing one `std::unique_ptr<int[]>` for each thread outside of the `par_for_skip` loop.
-3. Inside the loop, replace the `new` allocation with a simple pointer retrieval from the pre-allocated vector using the `cpu` thread ID: `int* nibbles = nibblesVec[cpu].get();`.
-4. Remove the `delete[] nibbles;` from the lambda.
-
-This mirrors the robust memory handling logic used by the neighboring function, `QEngineCPU::INCBCD`, entirely eliminating the memory leak risk and significantly improving execution performance.
+The allocation inside `src/qengine/arithmetic.cpp` (`int* nibbles = new int[nibbleCount];`) was the only one that dynamically allocated memory to a raw pointer within an inner loop scope where exceptions could cause a memory leak. Therefore, I can confidently confirm this is the only actual memory leak of its kind in the codebase.

--- a/SCRATCHPAD.md
+++ b/SCRATCHPAD.md
@@ -1,0 +1,36 @@
+# Memory Leak Suspect Report
+
+## Suspect Location
+**File**: `src/qengine/arithmetic.cpp`
+**Function**: `QEngineCPU::INCDECBCDC` (Binary Coded Decimal Arithmetic with Carry)
+**Line Range**: 926 - 977 (specifically, line 931)
+
+## Issue Description
+Within the `QEngineCPU::INCDECBCDC` function, there is a tight parallel loop implemented via `par_for_skip`.
+
+```cpp
+    par_for_skip(0, maxQPowerOcl, pow2Ocl(carryIndex), 1U, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
+        ...
+        int* nibbles = new int[nibbleCount]; // LINE 931
+        ...
+        delete[] nibbles; // LINE 976
+    });
+```
+
+During each iteration of this `par_for_skip` loop, the lambda function explicitly allocates a raw integer array using `new int[nibbleCount];`. Although there is a corresponding `delete[] nibbles;` at the end of the lambda, this code pattern is highly problematic and can cause a memory leak:
+
+1. **Exception Safety / Leak Scenario**: If any operation within this lambda throws an exception (e.g., during `nStateVec->write`), the `delete[] nibbles;` statement at the end of the lambda will be skipped. Because `nibbles` is a raw pointer and lacks RAII (Resource Acquisition Is Initialization) semantics like `std::unique_ptr` or `std::vector`, the allocated array will leak permanently.
+
+2. **Severe Heap Contention and Fragmentation**: The `par_for_skip` loop executes over `maxQPowerOcl` iterations (which scales exponentially with the number of qubits, frequently resulting in millions of concurrent iterations). Allocating and deallocating memory inside such a fine-grained, highly parallel loop exerts extreme pressure on the heap allocator. This leads to massive heap fragmentation, severe performance degradation, and peak memory usage that resembles a large leak, eventually triggering a failure if memory exhaustion occurs.
+
+## Recommended Fix (Implemented)
+
+The solution is to avoid performing memory allocations within the hot path of the parallel loop. Instead, thread-local buffers should be pre-allocated once per thread before the loop begins.
+
+**Resolution:**
+1. Determine the number of executing threads using `GetConcurrencyLevel()`.
+2. Allocate a `std::vector` containing one `std::unique_ptr<int[]>` for each thread outside of the `par_for_skip` loop.
+3. Inside the loop, replace the `new` allocation with a simple pointer retrieval from the pre-allocated vector using the `cpu` thread ID: `int* nibbles = nibblesVec[cpu].get();`.
+4. Remove the `delete[] nibbles;` from the lambda.
+
+This mirrors the robust memory handling logic used by the neighboring function, `QEngineCPU::INCBCD`, entirely eliminating the memory leak risk and significantly improving execution performance.

--- a/src/qengine/arithmetic.cpp
+++ b/src/qengine/arithmetic.cpp
@@ -923,12 +923,18 @@ void QEngineCPU::INCDECBCDC(const bitCapInt& toMod_, bitLenInt inOutStart, bitLe
     StateVectorPtr nStateVec = AllocStateVec(maxQPowerOcl);
     nStateVec->clear();
 
+    const unsigned numThreads = GetConcurrencyLevel();
+    std::vector<std::unique_ptr<int[]>> nibblesVec(numThreads);
+    for (size_t i = 0; i < numThreads; ++i) {
+        nibblesVec[i] = std::unique_ptr<int[]>(new int[nibbleCount]);
+    }
+
     par_for_skip(0, maxQPowerOcl, pow2Ocl(carryIndex), 1U, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
         const bitCapIntOcl otherRes = lcv & otherMask;
         bitCapIntOcl partToAdd = toModOcl;
         bitCapIntOcl inOutInt = (lcv & inOutMask) >> inOutStart;
         int test1, test2;
-        int* nibbles = new int[nibbleCount];
+        int* nibbles = nibblesVec[cpu].get();
         bool isValid = true;
 
         test1 = (int)(inOutInt & 15UL);
@@ -973,7 +979,6 @@ void QEngineCPU::INCDECBCDC(const bitCapInt& toMod_, bitLenInt inOutStart, bitLe
             nStateVec->write(lcv, stateVec->read(lcv));
             nStateVec->write(lcv | carryMask, stateVec->read(lcv | carryMask));
         }
-        delete[] nibbles;
     });
     ResetStateVec(nStateVec);
 }


### PR DESCRIPTION
Moved dynamic array allocation out of the hot path of the par_for_skip
parallel loop in QEngineCPU::INCDECBCDC. Previously, an array of ints
was allocated and deleted on every iteration, which caused severe heap
contention and potential memory leaks if exceptions were thrown.

Now, a std::vector of std::unique_ptr<int[]> is pre-allocated per CPU
thread before the loop starts, preventing both issues. Also documented
the memory leak suspect in SCRATCHPAD.md as requested.

---
*PR created automatically by Jules for task [10783427927976714746](https://jules.google.com/task/10783427927976714746) started by @twobombs*